### PR TITLE
settings.php and services.yml need not be executable.

### DIFF
--- a/scripts/composer/post-install.sh
+++ b/scripts/composer/post-install.sh
@@ -4,14 +4,14 @@
 if [ ! -f web/sites/default/settings.php ]
   then
     cp web/sites/default/default.settings.php web/sites/default/settings.php
-    chmod 777 web/sites/default/settings.php
+    chmod 666 web/sites/default/settings.php
 fi
 
 # Prepare the services file for installation
 if [ ! -f web/sites/default/services.yml ]
   then
     cp web/sites/default/default.services.yml web/sites/default/services.yml
-    chmod 777 web/sites/default/services.yml
+    chmod 666 web/sites/default/services.yml
 fi
 
 # Prepare the files directory for installation


### PR DESCRIPTION
Giving everything the 777 permissions works, because it basically disables all permission checks. That doesn't make it right though.

Changed the script to not add the executable bit to settings.php and services.yml.

Those permissions still are insecure though. For development on a local machine this is probably ok, but for deployment to a server more permissions than 440 or maybe 640 (if they are not owned by the user the web server runs as) are not acceptable.